### PR TITLE
Fix bug in castling logic

### DIFF
--- a/chess/start.py
+++ b/chess/start.py
@@ -383,6 +383,22 @@ class Game:
                         print("Castling not permitted: Path is obstructed.")
                     return False
 
+                # Ensure the king is not currently in check and does not pass
+                # through check while castling.
+                if self.board.is_in_check(self.turn):
+                    if not suppress_output:
+                        print("Castling not permitted: King is in check.")
+                    return False
+
+                step = 1 if end_pos[1] > start_pos[1] else -1
+                temp_board = copy.deepcopy(self.board)
+                temp_board.grid[start_pos[0]][start_pos[1]] = None
+                temp_board.grid[start_pos[0]][start_pos[1] + step] = copy.deepcopy(sim_piece)
+                if temp_board.is_in_check(self.turn):
+                    if not suppress_output:
+                        print("Castling not permitted: Path is under attack.")
+                    return False
+
                 # Move the king and the rook as part of the castling maneuver
                 new_board.grid[end_pos[0]][end_pos[1]] = sim_piece
                 new_board.grid[start_pos[0]][start_pos[1]] = None


### PR DESCRIPTION
## Summary
- enforce that the king cannot castle while in check
- prevent castling if the king would pass through a square under attack

## Testing
- `python3 -m py_compile chess/start.py`
- `python3 - <<'PY'
from chess.start import Game, Rook
G = Game()
for r in range(1,7):
    G.board.grid[r][4] = None
G.board.grid[7][4] = Rook('black')
G.board.grid[0][5] = None
G.board.grid[0][6] = None
print('Attempt castling while in check:')
print(G.process_move('e1 g1'))
PY`
- `python3 - <<'PY'
from chess.start import Game, Rook
G = Game()
G.board.grid[0][5] = None
G.board.grid[0][6] = None
for r in range(1,7):
    G.board.grid[r][5] = None
G.board.grid[7][5] = Rook('black')
print('Attempt castling with path under attack:')
print(G.process_move('e1 g1'))
PY`
